### PR TITLE
Frontend compatibility filter

### DIFF
--- a/frontend/lib/models/component_compatibility_provider.dart
+++ b/frontend/lib/models/component_compatibility_provider.dart
@@ -116,30 +116,61 @@ class ComponentCompatibilityService {
   }
 
   /// Gets all compatible component IDs for a given component.
+  /// Fetches compatibilities in both directions to ensure all links are found.
   Future<List<String>> getCompatibleComponentIds(String componentId) async {
     try {
-      final compatibilities = await getComponentCompatibilities(
-        componentIds: [componentId],
-        paging: false,
-      );
-      return compatibilities
-          .map((c) => c.compatibleComponentId)
-          .where((id) => id.isNotEmpty)
-          .toList();
+      final results = await Future.wait([
+        getComponentCompatibilities(
+          componentIds: [componentId],
+          paging: false,
+        ),
+        getComponentCompatibilities(
+          compatibleComponentIds: [componentId],
+          paging: false,
+        ),
+      ]);
+
+      final forwardCompatibilities = results[0];
+      final backwardCompatibilities = results[1];
+
+      final ids = <String>{};
+
+      for (var c in forwardCompatibilities) {
+        if (c.compatibleComponentId.isNotEmpty) {
+          ids.add(c.compatibleComponentId);
+        }
+      }
+
+      for (var c in backwardCompatibilities) {
+        if (c.componentId.isNotEmpty) {
+          ids.add(c.componentId);
+        }
+      }
+
+      return ids.toList();
     } catch (e) {
       rethrow;
     }
   }
 
   /// Checks if two components are compatible.
+  /// Checks both directions.
   Future<bool> areComponentsCompatible(String componentId1, String componentId2) async {
     try {
-      final compatibilities = await getComponentCompatibilities(
-        componentIds: [componentId1],
-        compatibleComponentIds: [componentId2],
-        paging: false,
-      );
-      return compatibilities.isNotEmpty;
+      final results = await Future.wait([
+        getComponentCompatibilities(
+          componentIds: [componentId1],
+          compatibleComponentIds: [componentId2],
+          paging: false,
+        ),
+        getComponentCompatibilities(
+          componentIds: [componentId2],
+          compatibleComponentIds: [componentId1],
+          paging: false,
+        ),
+      ]);
+      
+      return results[0].isNotEmpty || results[1].isNotEmpty;
     } catch (e) {
       return false;
     }
@@ -147,6 +178,7 @@ class ComponentCompatibilityService {
 
   /// Gets all components that are compatible with the given component.
   /// Returns a map of compatibility ID to compatible component ID.
+  /// Note: Returns only forward direction compatibilities to maintain map structure safely.
   Future<Map<String, String>> getCompatibleComponents(String componentId) async {
     try {
       final compatibilities = await getComponentCompatibilities(

--- a/frontend/lib/models/filter_provider.dart
+++ b/frontend/lib/models/filter_provider.dart
@@ -129,10 +129,21 @@ List<FilterDefinition> _mapBackendFieldsToDefinitions(
     );
   });
 
-  // Keep a stable order by label for UX
-  definitions.sort((a, b) => a.label.compareTo(b.label));
-  return definitions;
-}
+    // Keep a stable order by label for UX
+    definitions.sort((a, b) => a.label.compareTo(b.label));
+
+    // Add Compatibility filter
+    definitions.insert(
+      0,
+      const FilterDefinition(
+        key: 'Compatibility',
+        label: 'Compatibility',
+        type: FilterInputType.boolean,
+      ),
+    );
+
+    return definitions;
+  }
 
 String _humanizeKey(String key) {
   final withSpaces =

--- a/frontend/lib/screens/parts/part_picker_page.dart
+++ b/frontend/lib/screens/parts/part_picker_page.dart
@@ -93,9 +93,6 @@ class _PartPickerPageState extends ConsumerState<PartPickerPage> {
   // Unused fields removed to clean up warnings
   // The state is now fully managed by the activeFiltersProvider and DynamicFilterPanel
 
-  // Compatibility filter
-  bool _enableCompatibilityFilter = true;
-  
   // Track if we've shown the component details dialog for the current componentId
   String? _shownComponentId;
 
@@ -106,7 +103,10 @@ class _PartPickerPageState extends ConsumerState<PartPickerPage> {
     _currentPage = _sanitizePage(widget.initialPage);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // Clear previous filters on load to ensure clean state
-      ref.read(activeFiltersProvider(widget.componentType).notifier).clearAll();
+      final notifier = ref.read(activeFiltersProvider(widget.componentType).notifier);
+      notifier.clearAll();
+      // Set default compatibility filter to true
+      notifier.setFilter('Compatibility', true);
       _loadCurrentPage();
     });
   }
@@ -131,11 +131,10 @@ class _PartPickerPageState extends ConsumerState<PartPickerPage> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         // Clear filters when component type changes
         if (widget.componentType != oldWidget.componentType) {
-          ref.read(activeFiltersProvider(widget.componentType).notifier).clearAll();
+          final notifier = ref.read(activeFiltersProvider(widget.componentType).notifier);
+          notifier.clearAll();
           // Keep compatibility filter enabled by default on type change
-          setState(() {
-            _enableCompatibilityFilter = true;
-          });
+          notifier.setFilter('Compatibility', true);
         }
         _loadCurrentPage(force: true, targetPage: nextPage);
       });
@@ -163,6 +162,10 @@ class _PartPickerPageState extends ConsumerState<PartPickerPage> {
   Map<String, dynamic> _buildFilters() {
     final activeFilters =
         Map<String, dynamic>.from(ref.read(activeFiltersProvider(widget.componentType)));
+    
+    // Remove client-side only filters
+    activeFilters.remove('Compatibility');
+
     final query = _searchController.text.trim();
     if (query.isNotEmpty) {
       activeFilters['Query'] = query;
@@ -496,14 +499,23 @@ class _PartPickerPageState extends ConsumerState<PartPickerPage> {
     List<BaseComponent> products, {
     Set<String>? compatibleIds,
   }) {
+    final activeFilters = ref.watch(activeFiltersProvider(widget.componentType));
+    final compatibilityValue = activeFilters['Compatibility'];
+
     return products.where((product) {
       // Note: All filters except compatibility are handled server-side.
       // Compatibility filter
-      if (_enableCompatibilityFilter && compatibleIds != null) {
-        // If compatibility filter is enabled, only show products that are compatible
-        // with at least one component in the current build
-        if (!compatibleIds.contains(product.id)) {
-          return false;
+      if (compatibleIds != null) {
+        if (compatibilityValue == true) {
+          // If compatibility filter is Yes, only show products that are compatible
+          if (!compatibleIds.contains(product.id)) {
+            return false;
+          }
+        } else if (compatibilityValue == false) {
+          // If compatibility filter is No, only show products that are NOT compatible
+          if (compatibleIds.contains(product.id)) {
+            return false;
+          }
         }
       }
 

--- a/frontend/lib/screens/parts/part_picker_page.dart
+++ b/frontend/lib/screens/parts/part_picker_page.dart
@@ -479,12 +479,16 @@ class _PartPickerPageState extends ConsumerState<PartPickerPage> {
     );
 
     try {
-      for (final componentId in componentIds) {
-        final compatible = await service.getCompatibleComponentIds(componentId);
-        compatibleIds.addAll(compatible);
-        // Also add the component itself as compatible
-        compatibleIds.add(componentId);
+      // Fetch in parallel
+      final futures = componentIds.map((id) => service.getCompatibleComponentIds(id));
+      final results = await Future.wait(futures);
+      
+      for (final list in results) {
+        compatibleIds.addAll(list);
       }
+      
+      // Also add the components themselves as compatible
+      compatibleIds.addAll(componentIds);
     } catch (e) {
       debugPrint('Error fetching compatible components: $e');
     }


### PR DESCRIPTION
Add a client-side compatibility filter to the part picker page to allow users to filter parts based on their compatibility with the current build.

---
<a href="https://cursor.com/background-agent?bcId=bc-7926f52e-67f0-4685-bff3-d85a963a7684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7926f52e-67f0-4685-bff3-d85a963a7684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

